### PR TITLE
修正快捷键爱心符号错误

### DIFF
--- a/Resource/labelplus_config.xml
+++ b/Resource/labelplus_config.xml
@@ -42,7 +42,7 @@
         <Key>P</Key>
     </Item>    
     <Item>
-        <Text>❤</Text>
+        <Text>♥</Text>
         <Key>1</Key>
     </Item>    
     <Item>


### PR DESCRIPTION
修正快捷爱心符号`♥`与`♡`不匹配的问题