### PR TITLE
修复无法识别.PNG,.JPG,.TIFF文件的问题

### DIFF
--- a/LabelPlus/ManageImageFrm.cs
+++ b/LabelPlus/ManageImageFrm.cs
@@ -61,7 +61,7 @@ namespace LabelPlus
 
                 foreach (string extension in extension_list)
                 {
-                    if (tmp.Name.EndsWith(extension))
+                    if (tmp.Name.ToLower().EndsWith(extension))
                     {
                         listBoxFolderFile.Items.Add(tmp.Name);
                     } 


### PR DESCRIPTION
PNG和JPG也是常见扩展名，应该先将文件名转为小写再进行比较